### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "watch": "tsc -watch -p ./",
         "compile": "tsc -p ./",
         "pretest": "npm run compile",
-        "test": "jest --verbose"
+        "test": "jest --verbose --runInBand"
     },
     "files": [
         "dist/**/*"

--- a/test/tests/Artifactory/ArtifactoryClient.spec.ts
+++ b/test/tests/Artifactory/ArtifactoryClient.spec.ts
@@ -9,6 +9,11 @@ beforeAll(() => {
     nock.enableNetConnect(SERVER_URL);
 });
 
+afterAll(() => {
+    nock.cleanAll()
+    nock.enableNetConnect()
+})
+
 describe('Artifactory clients tests', () => {
     test('Client initialization', () => {
         const client = new ArtifactoryClient({ serverUrl: SERVER_URL });
@@ -17,7 +22,7 @@ describe('Artifactory clients tests', () => {
     test('Client w/o url', () => {
         expect(() => {
             const client = new ArtifactoryClient({ serverUrl: '' });
-        }).toThrow('Artifactory client : must provide serverUrl');
+        }).toThrow('Artifactory client : must provide platformUrl or artifactoryUrl');
     });
     test('System client', () => {
         const client = new ArtifactoryClient({ serverUrl: SERVER_URL });
@@ -38,7 +43,7 @@ test('Artifactory client header tests', async () => {
     const serviceId = 'jfrog@some.me';
     const scope: nock.Scope = nock(SERVER_URL)
         .matchHeader('header1', 'value')
-        .get('/api/v1/system/ping')
+        .get('/api/system/ping')
         .reply(200, serviceId);
     await client.system().ping();
     expect(scope.isDone()).toBeTruthy();

--- a/test/tests/Artifactory/ArtifactorySystemClient.spec.ts
+++ b/test/tests/Artifactory/ArtifactorySystemClient.spec.ts
@@ -15,6 +15,16 @@ describe('Artifactory System tests', () => {
     beforeAll(() => {
         jfrogClient = new JfrogClient(clientConfig);
     });
+    afterAll(() => {
+        nock.cleanAll();
+    });
+
+    test('Version', async () => {
+        const version: IArtifactoryVersion = await jfrogClient.artifactory().system().version();
+        expect(version.version).toBeTruthy();
+        expect(version.revision).toBeTruthy();
+        expect(isPassedThroughProxy).toBeFalsy();
+    });
 
     describe('Ping tests', () => {
         const PING_RES = 'OK';
@@ -111,20 +121,13 @@ describe('Artifactory System tests', () => {
         });
 
         test('Ping failure', async () => {
-            const PLATFORM_URL: string = faker.internet.url();
-            const scope = nock(PLATFORM_URL).get(`/api/system/ping`).reply(402, { message: 'error' });
-            const client = new JfrogClient({ platformUrl: PLATFORM_URL });
+            const platformUrl: string = faker.internet.url();
+            const scope = nock(platformUrl).get(`/artifactory/api/system/ping`).reply(402, { message: 'error' });
+            const client = new JfrogClient({ platformUrl });
             const res = await client.artifactory().system().ping();
             expect(res).toBeFalsy();
             expect(scope.isDone()).toBeTruthy();
             expect(isPassedThroughProxy).toBeFalsy();
         });
-    });
-
-    test('Version', async () => {
-        const version: IArtifactoryVersion = await jfrogClient.artifactory().system().version();
-        expect(version.version).toBeTruthy();
-        expect(version.revision).toBeTruthy();
-        expect(isPassedThroughProxy).toBeFalsy();
     });
 });

--- a/test/tests/HttpClient.spec.ts
+++ b/test/tests/HttpClient.spec.ts
@@ -12,43 +12,38 @@ beforeAll(() => {
     nock.enableNetConnect(serverUrl);
 });
 
+afterAll(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+});
+
 describe('Http client tests', () => {
     test('Constructing client', () => {
         const client = new HttpClient({ serverUrl });
         expect(client).toBeInstanceOf(HttpClient);
     });
-    test('Do request', async (done) => {
-        try {
-            nock(serverUrl).post(subPath).matchHeader('User-Agent', 'http-client-test').reply(200, 'RESPONSE');
-            const client = new HttpClient({ serverUrl, headers: { 'User-Agent': 'http-client-test' } });
-            const requestParams = {
-                method: 'POST',
-                url: subPath,
-            } as IRequestParams;
-            const res = await client.doRequest(requestParams);
-            expect(res).toBe('RESPONSE');
-            done();
-        } catch (e) {
-            done.fail(`Should not fail : ${e.message}`);
-        }
+    test('Do request', async () => {
+        nock(serverUrl).post(subPath).matchHeader('User-Agent', 'http-client-test').reply(200, 'RESPONSE');
+        const client = new HttpClient({ serverUrl, headers: { 'User-Agent': 'http-client-test' } });
+        const requestParams = {
+            method: 'POST',
+            url: subPath,
+        } as IRequestParams;
+        const res = await client.doRequest(requestParams);
+        expect(res).toBe('RESPONSE');
     });
-    test('Do auth request', async (done) => {
-        try {
-            nock(serverUrl)
-                .post(subPath)
-                .basicAuth({ user: username, pass: password })
-                .matchHeader('User-Agent', 'jfrog-client-js')
-                .reply(200, 'RESPONSE');
-            const client = new HttpClient({ serverUrl, username, password });
-            const requestParams = {
-                method: 'POST',
-                url: subPath,
-            } as IRequestParams;
-            const res = await client.doAuthRequest(requestParams);
-            expect(res).toBe('RESPONSE');
-            done();
-        } catch (e) {
-            done.fail(`Should not fail : ${e.message}`);
-        }
+    test('Do auth request', async () => {
+        nock(serverUrl)
+            .post(subPath)
+            .basicAuth({ user: username, pass: password })
+            .matchHeader('User-Agent', 'jfrog-client-js')
+            .reply(200, 'RESPONSE');
+        const client = new HttpClient({ serverUrl, username, password });
+        const requestParams = {
+            method: 'POST',
+            url: subPath,
+        } as IRequestParams;
+        const res = await client.doAuthRequest(requestParams);
+        expect(res).toBe('RESPONSE');
     });
 });

--- a/test/tests/Xray/XrayClient.spec.ts
+++ b/test/tests/Xray/XrayClient.spec.ts
@@ -9,6 +9,11 @@ beforeAll(() => {
     nock.enableNetConnect(SERVER_URL);
 });
 
+afterAll(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+});
+
 describe('Xray clients tests', () => {
     test('Client initialization', () => {
         const client = new XrayClient({ serverUrl: SERVER_URL });
@@ -17,7 +22,7 @@ describe('Xray clients tests', () => {
     test('Client w/o url', () => {
         expect(() => {
             const client = new XrayClient({ serverUrl: '' });
-        }).toThrow('Xray client : must provide serverUrl');
+        }).toThrow('Xray client : must provide platformUrl or xrayUrl');
     });
     test('System client', () => {
         const client = new XrayClient({ serverUrl: SERVER_URL });

--- a/test/tests/Xray/XraySystemClient.spec.ts
+++ b/test/tests/Xray/XraySystemClient.spec.ts
@@ -15,6 +15,17 @@ describe('Xray System tests', () => {
     beforeAll(() => {
         jfrogClient = new JfrogClient(clientConfig);
     });
+    afterAll(() => {
+        nock.cleanAll()
+    })
+
+    test('Version', async () => {
+        const version: IXrayVersion = await jfrogClient.xray().system().version();
+        expect(version.xray_version).toBeTruthy();
+        expect(version.xray_revision).toBeTruthy();
+        expect(isPassedThroughProxy).toBeFalsy();
+    });
+    
     describe('Ping tests', () => {
         const PING_RES = { status: 'pong' };
 
@@ -110,20 +121,13 @@ describe('Xray System tests', () => {
         });
 
         test('Ping failure', async () => {
-            const PLATFORM_URL: string = faker.internet.url();
-            const scope = nock(PLATFORM_URL).get(`/api/v1/system/ping`).reply(402, { message: 'error' });
-            const client = new JfrogClient({ platformUrl: PLATFORM_URL });
+            const platformUrl: string = faker.internet.url();
+            const scope = nock(platformUrl).get(`/xray/api/v1/system/ping`).reply(402, { message: 'error' });
+            const client = new JfrogClient({ platformUrl });
             const res = await client.xray().system().ping();
             expect(res).toBeFalsy();
             expect(scope.isDone()).toBeTruthy();
             expect(isPassedThroughProxy).toBeFalsy();
         });
-    });
-
-    test('Version', async () => {
-        const version: IXrayVersion = await jfrogClient.xray().system().version();
-        expect(version.xray_version).toBeTruthy();
-        expect(version.xray_revision).toBeTruthy();
-        expect(isPassedThroughProxy).toBeFalsy();
     });
 });


### PR DESCRIPTION
* Run tests in serial - some tests set environment variables on the running process which may affect other tests.
* nock should be cleaned.
* Mocked ping tests should mock URL to Artifactory and Xray APIs:
  * `/api/system/ping` -> `/artifactory/api/system/ping`
  * `/api/v1/system/ping` -> `/xray/api/v1/system/ping`
* `Client w/o url` tests checked incorrect message.