### PR TITLE
Allow providing the projectKey in details/build

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jfrogClient.xray().summary().component({
 #### Retrieving Xray Build Details
 
 ```javascript
-jfrogClient.xray().details().build('Build Name', '1')
+jfrogClient.xray().details().build('Build Name', '1', 'Project Key')
   .then(result => {
     console.log(JSON.stringify(result));
   })

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jfrogClient.xray().summary().component({
 #### Retrieving Xray Build Details
 
 ```javascript
-jfrogClient.xray().details().build('Build Name', '1', 'Project Key')
+jfrogClient.xray().details().build('Build Name', '1', 'Optional Project Key')
   .then(result => {
     console.log(JSON.stringify(result));
   })

--- a/model/Xray/Details/DetailsResponse.ts
+++ b/model/Xray/Details/DetailsResponse.ts
@@ -4,6 +4,7 @@ import { IDetailsError } from './Error';
 export interface IDetailsResponse {
     build_name: string;
     build_number: string;
+    project_key: string;
     is_scan_completed: boolean;
     components: IArtifact[];
     error_details: IDetailsError;

--- a/src/Xray/XrayDetailsClient.ts
+++ b/src/Xray/XrayDetailsClient.ts
@@ -5,11 +5,14 @@ import { ILogger } from '../../model/';
 export class XrayDetailsClient {
     constructor(private readonly httpClient: HttpClient, private readonly logger: ILogger) {}
 
-    public async build(buildName: string, buildNumber: string): Promise<IDetailsResponse> {
+    public async build(buildName: string, buildNumber: string, projectKey?: string): Promise<IDetailsResponse> {
         this.logger.debug('Sending build details request to Xray...');
-        const encodedUrl: string = `api/v1/details/build?build_name=${encodeURIComponent(
+        let encodedUrl: string = `api/v1/details/build?build_name=${encodeURIComponent(
             buildName
         )}&build_number=${encodeURIComponent(buildNumber)}`;
+        if (projectKey) {
+            encodedUrl += `&project_key=${encodeURIComponent(projectKey)}`;
+        }
         const requestParams: IRequestParams = {
             url: encodedUrl,
             method: 'GET',

--- a/test/tests/Xray/XrayDetailsClient.spec.ts
+++ b/test/tests/Xray/XrayDetailsClient.spec.ts
@@ -32,12 +32,14 @@ describe('Xray details tests', () => {
     test('Build details for non existing build', async () => {
         const buildName: string = 'buildDoesNotExist';
         const buildNumber: string = '123';
-        const response: IDetailsResponse = await jfrogClient.xray().details().build(buildName, buildNumber);
+        const projectKey: string = 'projectDoesNotExist';
+        const response: IDetailsResponse = await jfrogClient.xray().details().build(buildName, buildNumber, projectKey);
         expect(response).toBeTruthy();
 
         // Check general build details.
         expect(response.build_name).toBe(buildName);
         expect(response.build_number).toBe(buildNumber);
+        expect(response.project_key).toBe(projectKey);
         expect(response.is_scan_completed).toBe(false);
         expect(response.components).toBeFalsy();
 


### PR DESCRIPTION
Following the changes in https://github.com/jfrog/jfrog-vscode-extension/pull/135, I'd like to allow the JFrog VS-Code extension to use the same project key for the `details/build API`. A PR for the JFrog VS-Code extension will arrive soon after the merge of https://github.com/jfrog/jfrog-vscode-extension/pull/135.