### PR TITLE
Fix stream download

### DIFF
--- a/src/Artifactory/ArtifactoryDownloadClient.ts
+++ b/src/Artifactory/ArtifactoryDownloadClient.ts
@@ -27,23 +27,18 @@ export class ArtifactoryDownloadClient {
             method: 'GET',
             responseType: 'stream',
         };
-        const writer: fs.WriteStream = fs.createWriteStream(to, { flags: 'wx' });
+
+        let response: IClientResponse = await this.httpClient.doAuthRequest(requestParams);
         return new Promise((resolve, reject) => {
-            this.httpClient.doAuthRequest(requestParams).then((response) => {
-                if (response.status === 200) {
-                    response.data.pipe(writer);
-                } else {
-                    writer.close();
-                    reject(`Server responded with ${response.status}: ${response.data}`);
-                }
-            });
+            const writer: fs.WriteStream = fs.createWriteStream(to, { flags: 'w' });
+            response.data.pipe(writer);
             writer.on('finish', () => {
                 this.logger.debug('download from' + from + ' to ' + to + ' was successful');
+                writer.close();
                 resolve();
             });
             writer.on('error', (err) => {
                 this.logger.debug('download from' + from + ' to ' + to + ' was unsuccessful, Error:' + err);
-                writer.close();
                 reject(err);
             });
         });

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -31,7 +31,7 @@ export class TestUtils {
                 'items.find({' +
                     '"repo":"artifactory-build-info",' +
                     '"path":{"$match":"*"}}' +
-                    ').include("name","repo","path","created").sort({"$desc":["created"]}).limit(1)'
+                    ').include("name","repo","path","created","size").sort({"$desc":["created"]}).limit(1)'
             );
     }
 


### PR DESCRIPTION
Fix the following issues:
1. When downloading a non-existed artifact, the download hangs until timeout.
2. When downloading a non-existed artifact, the download creates an empty file.
3. Missing code coverage for negative flows in Artifact download.
