### PR TITLE
add Xray entitlement request

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Add jfrog-client-js as a dependency to your package.json file:
     - [Xray](#xray)
       - [Pinging Xray](#pinging-xray)
       - [Getting Xray Version](#getting-xray-version)
+      - [Checking Xray Entitlement](#checking-xray-entitlement)
       - [Scanning Bulk of Dependencies](#scanning-bulk-of-dependencies)
       - [Scanning a Dependency Tree with Consideration to the JFrog Project](#scanning-a-dependency-tree-with-consideration-to-the-jfrog-project)
       - [Scanning a Dependency Tree with Consideration to the Xray Watches](#scanning-a-dependency-tree-with-consideration-to-the-xray-watches)
@@ -89,6 +90,22 @@ jfrogClient
   .xray()
   .system()
   .version()
+  .then((result) => {
+    console.log(result);
+  })
+  .catch((error) => {
+    console.error(error);
+  });
+```
+
+#### Checking Xray Entitlement
+
+```javascript
+let feature = 'contextual_analysis';
+jfrogClient
+  .xray()
+  .entitlements()
+  .feature(feature)
   .then((result) => {
     console.log(result);
   })

--- a/model/Xray/Entitlements/Feature.ts
+++ b/model/Xray/Entitlements/Feature.ts
@@ -1,0 +1,4 @@
+export interface IFeatureEntitlement {
+    feature_id: string;
+    entitled: boolean;
+}

--- a/src/Xray/XrayClient.ts
+++ b/src/Xray/XrayClient.ts
@@ -6,6 +6,7 @@ import { XrayDetailsClient } from './XrayDetailsClient';
 import { IClientSpecificConfig } from '../../model/ClientSpecificConfig';
 import { ILogger } from '../../model/';
 import { XrayGraphClient as XrayScanClient } from '..';
+import { XrayEntitlementsClient } from './XrayEntitlementsClient';
 
 export class XrayClient {
     private readonly httpClient: HttpClient;
@@ -43,5 +44,9 @@ export class XrayClient {
 
     public scan(): XrayScanClient {
         return new XrayScanClient(this.httpClient, this.logger);
+    }
+
+    public entitlements(): XrayEntitlementsClient {
+        return new XrayEntitlementsClient(this.httpClient, this.logger);
     }
 }

--- a/src/Xray/XrayEntitlementsClient.ts
+++ b/src/Xray/XrayEntitlementsClient.ts
@@ -2,14 +2,14 @@ import { HttpClient, IRequestParams } from '../HttpClient';
 import { IClientResponse, ILogger } from '../../model/';
 
 export class XrayEntitlementsClient {
-    private readonly entitlementsEndpoint: string = '/api/v1/entitlements/feature/';
+    private readonly entitlementsFeatureEndpoint: string = '/api/v1/entitlements/feature/';
 
     constructor(private readonly httpClient: HttpClient, private readonly logger: ILogger) {}
 
     public async feature(feature: string): Promise<boolean> {
         this.logger.debug("Sending entitlement request for feature '" + feature + "'...");
         const requestParams: IRequestParams = {
-            url: this.entitlementsEndpoint + feature,
+            url: this.entitlementsFeatureEndpoint + feature,
             method: 'GET',
             timeout: HttpClient.DEFAULT_TIMEOUT_IN_MILLISECONDS,
         };

--- a/src/Xray/XrayEntitlementsClient.ts
+++ b/src/Xray/XrayEntitlementsClient.ts
@@ -1,0 +1,23 @@
+import { HttpClient, IRequestParams } from '../HttpClient';
+import { IClientResponse, ILogger } from '../../model/';
+
+export class XrayEntitlementsClient {
+    private readonly entitlementsEndpoint: string = '/api/v1/entitlements/feature/';
+
+    constructor(private readonly httpClient: HttpClient, private readonly logger: ILogger) {}
+
+    public async feature(feature: string): Promise<boolean> {
+        this.logger.debug("Sending entitlement request for feature '" + feature + "'...");
+        const requestParams: IRequestParams = {
+            url: this.entitlementsEndpoint + feature,
+            method: 'GET',
+            timeout: HttpClient.DEFAULT_TIMEOUT_IN_MILLISECONDS,
+        };
+        try {
+            let response: IClientResponse = await this.httpClient.doAuthRequest(requestParams);
+            return response.data?.entitled;
+        } catch (error) {
+            return false;
+        }
+    }
+}

--- a/test/tests/Xray/XrayClient.spec.ts
+++ b/test/tests/Xray/XrayClient.spec.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import { XrayDetailsClient, XraySummaryClient, XraySystemClient } from '../../../src';
 import { XrayClient } from '../../../src/Xray/XrayClient';
+import { XrayEntitlementsClient } from '../../../src/Xray/XrayEntitlementsClient';
 import { TestUtils } from '../../TestUtils';
 
 const SERVER_URL: string = 'http://localhost:8000';
@@ -36,6 +37,10 @@ describe('Xray clients tests', () => {
     test('Details client', () => {
         const client: XrayClient = new XrayClient({ serverUrl: SERVER_URL });
         expect(client.details()).toBeInstanceOf(XrayDetailsClient);
+    });
+    test('Entitlements client', () => {
+        const client: XrayClient = new XrayClient({ serverUrl: SERVER_URL });
+        expect(client.entitlements()).toBeInstanceOf(XrayEntitlementsClient);
     });
 });
 

--- a/test/tests/Xray/XrayEntitlementsClient.spec.ts
+++ b/test/tests/Xray/XrayEntitlementsClient.spec.ts
@@ -1,0 +1,47 @@
+import faker from 'faker';
+import nock from 'nock';
+import { JfrogClient } from '../../../src';
+import { TestUtils } from '../../TestUtils';
+
+describe('Xray Entitlements tests', () => {
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    let tests: any[] = [
+        {
+            test: 'pass',
+            feature: 'feature',
+            expected: true,
+        },
+        {
+            test: 'fail',
+            feature: 'feature',
+            expected: false,
+        },
+    ];
+
+    tests.forEach((testCase) => {
+        it('Feature - ' + testCase.test, async () => {
+            const platformUrl: string = faker.internet.url();
+            nock(platformUrl)
+                .get(`/xray/api/v1/entitlements/feature/` + testCase.feature)
+                .reply(200, { feature_id: testCase.feature, entitled: testCase.expected });
+            const client: JfrogClient = new JfrogClient({ platformUrl, logger: TestUtils.createTestLogger() });
+            const res: any = await client.xray().entitlements().feature(testCase.feature);
+            expect(res).toBe(testCase.expected);
+        });
+    });
+
+    test('Feature failure', async () => {
+        let feature: string = 'feature';
+        const platformUrl: string = faker.internet.url();
+        const scope: nock.Scope = nock(platformUrl)
+            .get(`/xray/api/v1/entitlements/feature/` + feature)
+            .reply(402, { message: 'error' });
+        const client: JfrogClient = new JfrogClient({ platformUrl, logger: TestUtils.createTestLogger() });
+        const res: any = await client.xray().entitlements().feature(feature);
+        expect(res).toBeFalsy();
+        expect(scope.isDone()).toBeTruthy();
+    });
+});


### PR DESCRIPTION
Adding entitlement request to test if the client has entitlement for Xray feature

```javascript
let feature = 'contextual_analysis';
jfrogClient
  .xray()
  .entitlements()
  .feature(feature)
  .then((result) => {
    console.log(result);
  })
  .catch((error) => {
    console.error(error);
  });
```
return true/false