### PR TITLE
Frogbot badge and workflows simplifications

### DIFF
--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -5,6 +5,8 @@ on:
     # You can add or replace to any branch you want to open fix pull requests for.
     branches:
       - "master"
+  schedule:
+    - cron: "0 0 * * *"
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -34,13 +34,3 @@ jobs:
           # [Mandatory]
           # The GitHub token automatically generated for the job
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          ###########################################################################
-          ##   If your project uses a 'frogbot-config.yml' file, you can define     ##
-          ##   the following variables inside the file, instead of here.           ##
-          ###########################################################################
-
-
-          # [Mandatory if the `installCommand` variable isn't set in your frogbot-config.yml file]
-          # The command that installs the project dependencies (e.g "npm i")
-          JF_INSTALL_DEPS_CMD: "npm ci --ignore-scripts"

--- a/.github/workflows/frogbot-scan-pr.yml
+++ b/.github/workflows/frogbot-scan-pr.yml
@@ -35,12 +35,3 @@ jobs:
           # [Mandatory]
           # The GitHub token automatically generated for the job
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          ###########################################################################
-          ##   If your project uses a 'frogbot-config.yml' file, you can define     ##
-          ##   the following variables inside the file, instead of here.           ##
-          ###########################################################################
-
-          # [Mandatory if the `installCommand` variable isn't set in your frogbot-config.yml file]
-          # The command that installs the project dependencies (e.g "npm i")
-          JF_INSTALL_DEPS_CMD: "npm ci --ignore-scripts"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # JFrog Javascript Client
 
-JFrog Javascript Client is a Javascript library, which wraps some REST APIs exposed by JFrog's different services.
-
-## Project Status
-
+[![Scanned by Frogbot](https://raw.github.com/jfrog/frogbot/master/images/frogbot-badge.svg)](https://github.com/jfrog/frogbot#readme)
 [![Tests](https://github.com/jfrog/jfrog-client-js/actions/workflows/test.yml/badge.svg)](https://github.com/jfrog/jfrog-client-js/actions/workflows/test.yml)
 [![Code coverage](https://codecov.io/github/jfrog/jfrog-client-js/coverage.svg?branch=master)](https://codecov.io/github/jfrog/jfrog-client-js?branch=master)
+
+JFrog Javascript Client is a Javascript library, which wraps some REST APIs exposed by JFrog's different services.
 
 ## Contributions
 
@@ -23,28 +22,23 @@ Add jfrog-client-js as a dependency to your package.json file:
 
 ## APIs
 
-- [JFrog Javascript Client](#jfrog-javascript-client)
-  - [Project Status](#project-status)
-  - [Contributions](#contributions)
-  - [Getting started](#getting-started)
-  - [APIs](#apis)
-    - [Setting up JFrog client](#setting-up-jfrog-client)
-    - [Xray](#xray)
-      - [Pinging Xray](#pinging-xray)
-      - [Getting Xray Version](#getting-xray-version)
-      - [Checking Xray Entitlement](#checking-xray-entitlement)
-      - [Scanning Bulk of Dependencies](#scanning-bulk-of-dependencies)
-      - [Scanning a Dependency Tree with Consideration to the JFrog Project](#scanning-a-dependency-tree-with-consideration-to-the-jfrog-project)
-      - [Scanning a Dependency Tree with Consideration to the Xray Watches](#scanning-a-dependency-tree-with-consideration-to-the-xray-watches)
-      - [Retrieving Xray Build Details](#retrieving-xray-build-details)
-    - [Artifactory](#artifactory)
-      - [Pinging Artifactory](#pinging-artifactory)
-      - [Getting Artifactory Version](#getting-artifactory-version)
-      - [Downloading an Artifact](#downloading-an-artifact)
-      - [Downloading an Artifact content](#downloading-an-artifact-content)
-      - [Downloading an Artifact to file](#downloading-an-artifact-to-file)
-      - [Downloading an Artifact checksum](#downloading-an-artifact-checksum)
-      - [Searching by AQL](#searching-by-aql)
+  - [Setting up JFrog client](#setting-up-jfrog-client)
+  - [Xray](#xray)
+    - [Pinging Xray](#pinging-xray)
+    - [Getting Xray Version](#getting-xray-version)
+    - [Checking Xray Entitlement](#checking-xray-entitlement)
+    - [Scanning Bulk of Dependencies](#scanning-bulk-of-dependencies)
+    - [Scanning a Dependency Tree with Consideration to the JFrog Project](#scanning-a-dependency-tree-with-consideration-to-the-jfrog-project)
+    - [Scanning a Dependency Tree with Consideration to the Xray Watches](#scanning-a-dependency-tree-with-consideration-to-the-xray-watches)
+    - [Retrieving Xray Build Details](#retrieving-xray-build-details)
+  - [Artifactory](#artifactory)
+    - [Pinging Artifactory](#pinging-artifactory)
+    - [Getting Artifactory Version](#getting-artifactory-version)
+    - [Downloading an Artifact](#downloading-an-artifact)
+    - [Downloading an Artifact content](#downloading-an-artifact-content)
+    - [Downloading an Artifact to file](#downloading-an-artifact-to-file)
+    - [Downloading an Artifact checksum](#downloading-an-artifact-checksum)
+    - [Searching by AQL](#searching-by-aql)
 
 ### Setting up JFrog client
 


### PR DESCRIPTION
* Since Frogbot no longer requires the JF_INSTALL_DEPS_CMD variable for npm, this PR removes it from the Frogbot workflows.
* Added the Frogbot badge to the README.
* Moved the labels to the top of the README and removed redundant entries for README's table of contents.