### PR TITLE
Promote Axios to v1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.7.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "axios": "~0.27.2",
+                "axios": "~1.6.2",
                 "axios-retry": "~3.2.5",
                 "https-proxy-agent": "^5.0.1"
             },
@@ -1652,12 +1652,13 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/axios-retry": {
@@ -4637,6 +4638,11 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -6579,12 +6585,13 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "requires": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "axios-retry": {
@@ -8812,6 +8819,11 @@
             "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
             "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
             "dev": true
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "punycode": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "dist/**/*"
     ],
     "dependencies": {
-        "axios": "~0.27.2",
+        "axios": "~1.6.2",
         "axios-retry": "~3.2.5",
         "https-proxy-agent": "^5.0.1"
     },

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -72,10 +72,10 @@ export class HttpClient {
      * Method to use for beforeRedirect attribute in IRequestParams.
      * Before redirecting checks if the target location for the redirect is for 'reactivate-server' and throws ServerNotActiveError if so.
      */
-    public static validateServerIsActive(_: Record<string, any>, responseDetails: { headers: Record<string, string> }) {
-        let movedLocation: string | undefined = responseDetails?.headers['location'];
-        if (movedLocation && movedLocation.includes('reactivate-server')) {
-            throw new ServerNotActiveError(movedLocation);
+    public static validateServerIsActive(responseDetails: Record<string, any>, _: { headers: Record<string, string> }) {
+        let redirectedUrl: string | undefined = responseDetails?.href;
+        if (redirectedUrl && redirectedUrl.includes('/reactivate-server/')) {
+            throw new ServerNotActiveError(redirectedUrl);
         }
     }
 

--- a/test/tests/Xray/XraySystemClient.spec.ts
+++ b/test/tests/Xray/XraySystemClient.spec.ts
@@ -36,8 +36,9 @@ describe('Xray System tests', () => {
         beforeEach(nock.cleanAll.bind(nock));
 
         test('Version failure - server not active', async () => {
+            const baseUrl: string = 'https://landing.jfrog.info/reactivate-server/ecosysjfrog';
             const client: JfrogClient = new JfrogClient({
-                platformUrl: 'https://httpbin.org/redirect-to?url=reactivate-server',
+                platformUrl: 'https://httpbin.org/redirect-to?url=' + baseUrl,
                 logger: TestUtils.createTestLogger(),
             });
             let errFound: boolean = false;
@@ -46,10 +47,10 @@ describe('Xray System tests', () => {
             } catch (err: any) {
                 errFound = true;
                 expect(err.activationUrl).toBeDefined();
-                // This result only expected for the test (using httpbin with the redirect-to flag cause this).
+                // This result only expected for the test.
                 // Actual activationUrl will be equal to the location without the added relative path to the version request.
                 // The JFrog client concat to the location the relative path of the version request.
-                expect(err.activationUrl).toBe('reactivate-server/xray' + XraySystemClient.versionEndpoint);
+                expect(err.activationUrl).toBe(baseUrl + '/xray' + XraySystemClient.versionEndpoint);
             }
             expect(errFound).toBeTruthy();
             expect(isPassedThroughProxy).toBeFalsy();


### PR DESCRIPTION

Upgrade the `Axios` package to version `1.6.2` and resolve the issue resulting from the update to a new major version.


Issues resolved in this update:

* Handling of redirects has been adjusted.