### PR TITLE
Jas config api for client-js

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "CLA Assistant"
         if: ${{ steps.sign-or-recheck.outputs.match != '' || github.event_name == 'pull_request_target' }}
         # Alpha Release
-        uses: cla-assistant/github-action@v2.1.1-beta
+        uses: cla-assistant/github-action@v2.6.0
         env:
           # Generated and maintained by github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Add jfrog-client-js as a dependency to your package.json file:
   - [Scanning a Dependency Tree with Consideration to the JFrog Project](#scanning-a-dependency-tree-with-consideration-to-the-jfrog-project)
   - [Scanning a Dependency Tree with Consideration to the Xray Watches](#scanning-a-dependency-tree-with-consideration-to-the-xray-watches)
   - [Retrieving Xray Build Details](#retrieving-xray-build-details)
+  - [Retrieving JAS configuration](#retrieving-jas-configuration)
 - [Artifactory](#artifactory)
   - [Pinging Artifactory](#pinging-artifactory)
   - [Getting Artifactory Version](#getting-artifactory-version)
@@ -191,6 +192,20 @@ jfrogClient
   .xray()
   .details()
   .build('Build Name', '1', 'Optional Project Key')
+  .then((result) => {
+    console.log(JSON.stringify(result));
+  })
+  .catch((error) => {
+    console.error(error);
+  });
+```
+
+#### Retrieving JAS configuration
+```javascript
+jfrogClient
+  .xray()
+  .jasconfig()
+  .getJasConfig()      
   .then((result) => {
     console.log(JSON.stringify(result));
   })

--- a/model/Xray/JasConfig/JasConfig.ts
+++ b/model/Xray/JasConfig/JasConfig.ts
@@ -1,3 +1,3 @@
 export interface IJasConfig {
-  enable_token_validation_scanning: boolean;
+    enable_token_validation_scanning: boolean;
 }

--- a/model/Xray/JasConfig/JasConfig.ts
+++ b/model/Xray/JasConfig/JasConfig.ts
@@ -1,0 +1,3 @@
+export interface IJasConfig {
+  enable_token_validation_scanning: boolean;
+}

--- a/src/Xray/XrayClient.ts
+++ b/src/Xray/XrayClient.ts
@@ -71,6 +71,6 @@ export class XrayClient {
     }
 
     public jasconfig(): XrayJasConfigClient {
-      return new XrayJasConfigClient(this.httpClient, this.logger);
+        return new XrayJasConfigClient(this.httpClient, this.logger);
     }
 }

--- a/src/Xray/XrayClient.ts
+++ b/src/Xray/XrayClient.ts
@@ -7,6 +7,7 @@ import { IClientSpecificConfig } from '../../model/ClientSpecificConfig';
 import { ILogger } from '../../model/';
 import { XrayGraphClient as XrayScanClient } from '..';
 import { XrayEntitlementsClient } from './XrayEntitlementsClient';
+import { XrayJasConfigClient } from './XrayJasConfigClient';
 
 export class XrayClient {
     static readonly scanGraphEndpoint: string = 'api/v1/scan/graph';
@@ -67,5 +68,9 @@ export class XrayClient {
 
     public entitlements(): XrayEntitlementsClient {
         return new XrayEntitlementsClient(this.httpClient, this.logger);
+    }
+
+    public jasconfig(): XrayJasConfigClient {
+      return new XrayJasConfigClient(this.httpClient, this.logger);
     }
 }

--- a/src/Xray/XrayJasConfigClient.ts
+++ b/src/Xray/XrayJasConfigClient.ts
@@ -9,34 +9,19 @@ export class XrayJasConfigClient {
      *
      * Sends 'GET /configuration/js requests to Xray and waits for 200 response'.
      * @returns the jas config
-     * @throws an exception if an unexpected response received from Xray or if checkCanceled threw an exception
+     * @throws an exception if an unexpected response received from Xray
      */
     async getJasConfig(): Promise<IJasConfig> {
         this.logger.debug(`Sending GET ${this.jasConfigurationEndpoint} request...`);
-        let receivedStatus: number | undefined;
         const requestParams: IRequestParams = {
             url: this.jasConfigurationEndpoint,
             method: 'GET',
             validateStatus: (status: number): boolean => {
-                receivedStatus = status;
                 return status === 200;
             },
         };
-        let message: string | undefined;
-        let response: IClientResponse | undefined;
-        try {
-            response = await this.httpClient.doAuthRequest(requestParams);
-        } catch (error) {
-            throw new Error(`Received unexpected response from Xray. ${String(error)}`);
-        }
-        this.logger.debug(`Received status '${receivedStatus}' from Xray.`);
-        if (receivedStatus === 200) {
-            return response?.data;
-        } else {
-            if (receivedStatus) {
-                throw new Error(`Received unexpected status '${receivedStatus}' from Xray: ${message}`);
-            }
-            throw new Error(`Received response from Xray: ${message}`);
-        }
+        return await (
+          await this.httpClient.doAuthRequest(requestParams)
+        ).data;
     }
 }

--- a/src/Xray/XrayJasConfigClient.ts
+++ b/src/Xray/XrayJasConfigClient.ts
@@ -1,0 +1,44 @@
+import { HttpClient, IRequestParams } from '../HttpClient';
+import { IClientResponse, ILogger } from '../../model';
+import { IJasConfig } from '../../model/Xray/JasConfig/JasConfig';
+
+export class XrayJasConfigClient {
+  private readonly jasConfigurationEndpoint: string = '/api/v1/configuration/jas';
+  constructor(private readonly httpClient: HttpClient, private readonly logger: ILogger) {}
+  /**
+   *
+   * Sends 'GET /configuration/js requests to Xray and waits for 200 response'.
+   * @returns the jas config
+   * @throws an exception if an unexpected response received from Xray or if checkCanceled threw an exception
+   */
+  async getJasConfig(): Promise<IJasConfig> {
+      this.logger.debug(`Sending GET ${this.jasConfigurationEndpoint} request...`);
+      let receivedStatus: number | undefined;
+      const requestParams: IRequestParams = {
+        url: this.jasConfigurationEndpoint,
+        method: 'GET',
+        validateStatus: (status: number): boolean => {
+          receivedStatus = status;
+          return status === 200;
+        },
+      };
+      let message: string | undefined;
+      let response: IClientResponse | undefined;
+      try {
+        response = await this.httpClient.doAuthRequest(requestParams);
+      } catch (error) {
+        throw new Error(`Received unexpected response from Xray. ${String(error)}`);
+      }
+      this.logger.debug(`Received status '${receivedStatus}' from Xray.`);
+      if (receivedStatus === 200) {
+        return response?.data;
+      }
+      else {
+        if (receivedStatus) {
+          throw new Error(`Received unexpected status '${receivedStatus}' from Xray: ${message}`);
+        }
+        throw new Error(`Received response from Xray: ${message}`);
+      }
+  }
+
+}

--- a/src/Xray/XrayJasConfigClient.ts
+++ b/src/Xray/XrayJasConfigClient.ts
@@ -3,42 +3,40 @@ import { IClientResponse, ILogger } from '../../model';
 import { IJasConfig } from '../../model/Xray/JasConfig/JasConfig';
 
 export class XrayJasConfigClient {
-  private readonly jasConfigurationEndpoint: string = '/api/v1/configuration/jas';
-  constructor(private readonly httpClient: HttpClient, private readonly logger: ILogger) {}
-  /**
-   *
-   * Sends 'GET /configuration/js requests to Xray and waits for 200 response'.
-   * @returns the jas config
-   * @throws an exception if an unexpected response received from Xray or if checkCanceled threw an exception
-   */
-  async getJasConfig(): Promise<IJasConfig> {
-      this.logger.debug(`Sending GET ${this.jasConfigurationEndpoint} request...`);
-      let receivedStatus: number | undefined;
-      const requestParams: IRequestParams = {
-        url: this.jasConfigurationEndpoint,
-        method: 'GET',
-        validateStatus: (status: number): boolean => {
-          receivedStatus = status;
-          return status === 200;
-        },
-      };
-      let message: string | undefined;
-      let response: IClientResponse | undefined;
-      try {
-        response = await this.httpClient.doAuthRequest(requestParams);
-      } catch (error) {
-        throw new Error(`Received unexpected response from Xray. ${String(error)}`);
-      }
-      this.logger.debug(`Received status '${receivedStatus}' from Xray.`);
-      if (receivedStatus === 200) {
-        return response?.data;
-      }
-      else {
-        if (receivedStatus) {
-          throw new Error(`Received unexpected status '${receivedStatus}' from Xray: ${message}`);
+    private readonly jasConfigurationEndpoint: string = '/api/v1/configuration/jas';
+    constructor(private readonly httpClient: HttpClient, private readonly logger: ILogger) {}
+    /**
+     *
+     * Sends 'GET /configuration/js requests to Xray and waits for 200 response'.
+     * @returns the jas config
+     * @throws an exception if an unexpected response received from Xray or if checkCanceled threw an exception
+     */
+    async getJasConfig(): Promise<IJasConfig> {
+        this.logger.debug(`Sending GET ${this.jasConfigurationEndpoint} request...`);
+        let receivedStatus: number | undefined;
+        const requestParams: IRequestParams = {
+            url: this.jasConfigurationEndpoint,
+            method: 'GET',
+            validateStatus: (status: number): boolean => {
+                receivedStatus = status;
+                return status === 200;
+            },
+        };
+        let message: string | undefined;
+        let response: IClientResponse | undefined;
+        try {
+            response = await this.httpClient.doAuthRequest(requestParams);
+        } catch (error) {
+            throw new Error(`Received unexpected response from Xray. ${String(error)}`);
         }
-        throw new Error(`Received response from Xray: ${message}`);
-      }
-  }
-
+        this.logger.debug(`Received status '${receivedStatus}' from Xray.`);
+        if (receivedStatus === 200) {
+            return response?.data;
+        } else {
+            if (receivedStatus) {
+                throw new Error(`Received unexpected status '${receivedStatus}' from Xray: ${message}`);
+            }
+            throw new Error(`Received response from Xray: ${message}`);
+        }
+    }
 }

--- a/src/Xray/XrayJasConfigClient.ts
+++ b/src/Xray/XrayJasConfigClient.ts
@@ -1,5 +1,5 @@
 import { HttpClient, IRequestParams } from '../HttpClient';
-import { IClientResponse, ILogger } from '../../model';
+import { ILogger } from '../../model';
 import { IJasConfig } from '../../model/Xray/JasConfig/JasConfig';
 
 export class XrayJasConfigClient {

--- a/test/tests/Xray/XrayJasConfig.spec.ts
+++ b/test/tests/Xray/XrayJasConfig.spec.ts
@@ -6,16 +6,16 @@ import { TestUtils } from '../../TestUtils';
 let jfrogClient: JfrogClient;
 
 beforeAll(() => {
-  jfrogClient = new JfrogClient(TestUtils.getJfrogClientConfig());
+    jfrogClient = new JfrogClient(TestUtils.getJfrogClientConfig());
 });
 
 describe('Xray jas config tests', () => {
-  test('Get jas config', async () => {
-    const PLATFORM_URL: string = faker.internet.url();
-    const uri: string = `/xray/api/v1/configuration/jas`
-    const expectedResource: string = '{"enable_token_validation_scanning": true}'
-    nock(PLATFORM_URL).get(uri).reply(200, expectedResource);
-    const res: any = await jfrogClient.xray().jasconfig().getJasConfig()
-    expect(res).toEqual(JSON.parse(expectedResource));
-  });
+    test('Get jas config', async () => {
+        const PLATFORM_URL: string = faker.internet.url();
+        const uri: string = `/xray/api/v1/configuration/jas`;
+        const expectedResource: string = '{"enable_token_validation_scanning": true}';
+        nock(PLATFORM_URL).get(uri).reply(200, expectedResource);
+        const res: any = await jfrogClient.xray().jasconfig().getJasConfig();
+        expect(res).toEqual(JSON.parse(expectedResource));
+    });
 });

--- a/test/tests/Xray/XrayJasConfig.spec.ts
+++ b/test/tests/Xray/XrayJasConfig.spec.ts
@@ -2,12 +2,8 @@ import faker from 'faker';
 import nock from 'nock';
 import { JfrogClient } from '../../../src';
 import { TestUtils } from '../../TestUtils';
-
-let jfrogClient: JfrogClient;
-
-beforeAll(() => {
-    jfrogClient = new JfrogClient(TestUtils.getJfrogClientConfig());
-});
+import { IGraphRequestModel } from '../../../model';
+import { IJasConfig } from '../../../model/Xray/JasConfig/JasConfig';
 
 describe('Xray jas config tests', () => {
     test('Get jas config', async () => {
@@ -15,7 +11,24 @@ describe('Xray jas config tests', () => {
         const uri: string = `/xray/api/v1/configuration/jas`;
         const expectedResource: string = '{"enable_token_validation_scanning": true}';
         nock(PLATFORM_URL).get(uri).reply(200, expectedResource);
-        const res: any = await jfrogClient.xray().jasconfig().getJasConfig();
-        expect(res).toEqual(JSON.parse(expectedResource));
+        const client: JfrogClient = new JfrogClient({ platformUrl: PLATFORM_URL, logger: TestUtils.createTestLogger() });
+        const res: any = await client.xray().jasconfig().getJasConfig();
+        expect(res).toHaveProperty("enable_token_validation_scanning")
+        expect(res.enable_token_validation_scanning).toEqual(true)
+    });
+});
+
+describe('Xray jas config tests', () => {
+    test('Fail get jas config', async () => {
+        const PLATFORM_URL: string = faker.internet.url();
+        const uri: string = `/xray/api/v1/configuration/jas`;
+        nock(PLATFORM_URL).get(uri).reply(402, { message: 'error' }).persist();
+        const client: JfrogClient = new JfrogClient({ platformUrl: PLATFORM_URL, logger: TestUtils.createTestLogger() })
+        await expect(async () => {
+            await client
+              .xray()
+              .jasconfig()
+              .getJasConfig();
+        }).rejects.toThrow(`Request failed with status code 402`);
     });
 });

--- a/test/tests/Xray/XrayJasConfig.spec.ts
+++ b/test/tests/Xray/XrayJasConfig.spec.ts
@@ -2,8 +2,6 @@ import faker from 'faker';
 import nock from 'nock';
 import { JfrogClient } from '../../../src';
 import { TestUtils } from '../../TestUtils';
-import { IGraphRequestModel } from '../../../model';
-import { IJasConfig } from '../../../model/Xray/JasConfig/JasConfig';
 
 describe('Xray jas config tests', () => {
     test('Get jas config', async () => {

--- a/test/tests/Xray/XrayJasConfig.spec.ts
+++ b/test/tests/Xray/XrayJasConfig.spec.ts
@@ -1,0 +1,21 @@
+import faker from 'faker';
+import nock from 'nock';
+import { JfrogClient } from '../../../src';
+import { TestUtils } from '../../TestUtils';
+
+let jfrogClient: JfrogClient;
+
+beforeAll(() => {
+  jfrogClient = new JfrogClient(TestUtils.getJfrogClientConfig());
+});
+
+describe('Xray jas config tests', () => {
+  test('Get jas config', async () => {
+    const PLATFORM_URL: string = faker.internet.url();
+    const uri: string = `/xray/api/v1/configuration/jas`
+    const expectedResource: string = '{"enable_token_validation_scanning": true}'
+    nock(PLATFORM_URL).get(uri).reply(200, expectedResource);
+    const res: any = await jfrogClient.xray().jasconfig().getJasConfig()
+    expect(res).toEqual(JSON.parse(expectedResource));
+  });
+});

--- a/test/tests/Xray/XraySummaryClient.spec.ts
+++ b/test/tests/Xray/XraySummaryClient.spec.ts
@@ -126,7 +126,7 @@ describe('Xray summary tests', () => {
         const license: ILicense = licenses[0];
         expect(license.name).toBe('MIT');
         expect(license.full_name).toBe('MIT License');
-        expect(license.more_info_url.length).toBeGreaterThanOrEqual(4);
+        expect(license.more_info_url.length).toBeGreaterThanOrEqual(3);
         expect(license.components.length).toBe(1);
         expect(license.components[0]).toBe('npm://js-yaml:3.10.0');
     });

--- a/test/tests/Xray/XraySummaryClient.spec.ts
+++ b/test/tests/Xray/XraySummaryClient.spec.ts
@@ -125,7 +125,7 @@ describe('Xray summary tests', () => {
 
         const license: ILicense = licenses[0];
         expect(license.name).toBe('MIT');
-        expect(license.full_name).toBe('The MIT License');
+        expect(license.full_name).toBe('MIT License');
         expect(license.more_info_url.length).toBeGreaterThanOrEqual(4);
         expect(license.components.length).toBe(1);
         expect(license.components[0]).toBe('npm://js-yaml:3.10.0');


### PR DESCRIPTION
XRay API to get jas configuration. Currently only holds value of enable_token_validation, which tells us if token validation is enabled on platform side.